### PR TITLE
Hotfix: Fixed Dockerfile to mount /upload with physical system ../upload

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ RUN mkdir /entry
 ADD ./entry /entry/
 ADD requirements.txt /entry/
 RUN pip install -r /entry/requirements.txt
-RUN mkdir /static
-RUN mkdir /code
+RUN mkdir /static && mkdir /upload && mkdir /code
 ADD ./src /code/
 WORKDIR /code

--- a/docker-compose.override.production.yml
+++ b/docker-compose.override.production.yml
@@ -7,5 +7,6 @@ services:
       DJANGO_ALLOWED_HOSTS: (Replace with your allowed hosts / ex: example1.com:example2.com)
     volumes:
       - ../static:/static
+      - ../upload:/upload
     ports:
       - "127.0.0.1:8000:8000"

--- a/src/plus_study/settings.py
+++ b/src/plus_study/settings.py
@@ -127,6 +127,9 @@ USE_TZ = True
 STATIC_URL = '/static/'
 STATIC_ROOT = '/static'
 
+MEDIA_URL = ''
+MEDIA_ROOT = '/upload'
+
 AUTH_USER_MODEL = 'website.User'
 
 LOGIN_REDIRECT_URL = '/'


### PR DESCRIPTION
Using volumes in docker, uploaded attachments are not removed between image rebuild.