### PR TITLE
Bump django from 3.1.7 to 3.2.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==3.1.7
+Django==3.2.6
 django-cleanup
 psycopg2-binary
 gunicorn


### PR DESCRIPTION
# Security Issue
## [CVE-2021-35042](https://www.cvedetails.com/cve/CVE-2021-35042/)
Django 3.1.x before 3.1.13 and 3.2.x before 3.2.5 allows QuerySet.order_by SQL injection if order_by is untrusted input from a client of a web application. 